### PR TITLE
Implement USB device `index` in `open_device`

### DIFF
--- a/src/device/device_handle.rs
+++ b/src/device/device_handle.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 use crate::error::Result;
 use crate::error::RtlsdrError::RtlsdrErr;
 use rusb::{Context, UsbContext};
+use log::{error, info};
 
 use super::KNOWN_DEVICES;
-
 #[derive(Debug)]
 pub struct DeviceHandle {
     handle: rusb::DeviceHandle<Context>,
@@ -16,24 +16,57 @@ impl DeviceHandle {
         let handle = DeviceHandle::open_device(&mut context, index)?;
         Ok(DeviceHandle { handle: handle })
     }
-
     pub fn open_device<T: UsbContext>(
         context: &mut T,
-        _index: usize,
+        index: usize,
     ) -> Result<rusb::DeviceHandle<T>> {
-        let devices = context.devices().map(|d| d)?;
+        let devices = context.devices().map_err(|e| {
+            info!("Failed to get devices: {:?}", e);  // Logging with info!
+            RtlsdrErr(format!("Error: {:?}", e))
+        })?;
+    
+        let mut device_count = 0;
+    
+        // Iterate through the devices and check their descriptors
+        for (i, found) in devices.iter().enumerate() {
+            let device_desc = match found.device_descriptor() {
+                Ok(desc) => desc,
+                Err(e) => {
+                    info!("Failed to get device descriptor for device {}: {:?}", i, e);  // Logging with info!
+                    continue;
+                }
+            };
 
-        let _device = for found in devices.iter() {
-            let device_desc = found.device_descriptor().map(|d| d)?;
             for dev in KNOWN_DEVICES.iter() {
                 if device_desc.vendor_id() == dev.vid && device_desc.product_id() == dev.pid {
-                    return Ok(found.open()?);
+                    info!(
+                        "Found device at index {} Vendor ID = {:04x}, Product ID = {:04x}",
+                        i, device_desc.vendor_id(), device_desc.product_id()
+                    );
+    
+                    if device_count == index {
+                        info!("Opening device at index {}", index);  // Logging with info!
+                        return found.open().map_err(|e| {
+                            info!("Failed to open device: {:?}", e);  // Logging with info!
+                            RtlsdrErr(format!("Error: {:?}", e))
+                        });
+                    }
+                    device_count += 1;
                 }
             }
-        };
-        Err(RtlsdrErr(format!("No device found")))
+        }
+    
+        info!(
+            "No matching device found at the requested index {}. Total matched devices: {}",
+            index, device_count
+        );  // Logging with info!
+    
+        Err(RtlsdrErr(format!(
+            "No device found at index {}",
+            index
+        )))
     }
-
+    
     pub fn claim_interface(&mut self, iface: u8) -> Result<()> {
         Ok(self.handle.claim_interface(iface)?)
     }


### PR DESCRIPTION
Originally we just open the first recognized device we find and ignore the provided device `index` param.

This PR instead iterates the recognized devices, opening the device at `index`.