### PR TITLE
Fix set_freq_correction not applying PPM to tuner

### DIFF
--- a/src/rtlsdr.rs
+++ b/src/rtlsdr.rs
@@ -35,7 +35,6 @@ pub struct RtlSdr {
     direct_sampling: DirectSampleMode,
     xtal: u32,
     tuner_xtal: u32,
-    ppm_correction: u32,
     offset_freq: u32,
     corr: i32, // PPM
     force_bt: bool,
@@ -51,7 +50,6 @@ impl RtlSdr {
             freq: 0,
             rate: 0,
             bw: 0,
-            ppm_correction: 0,
             xtal: DEF_RTL_XTAL_FREQ,
             tuner_xtal: DEF_RTL_XTAL_FREQ,
             direct_sampling: DirectSampleMode::Off,
@@ -364,11 +362,11 @@ impl RtlSdr {
 
     #[allow(dead_code)]
     pub fn get_xtal_freq(&self) -> u32 {
-        (self.xtal as f32 * (1.0 + self.ppm_correction as f32 / 1e6)) as u32
+        (self.xtal as f32 * (1.0 + self.corr as f32 / 1e6)) as u32
     }
 
     pub fn get_tuner_xtal_freq(&self) -> u32 {
-        (self.tuner_xtal as f32 * (1.0 + self.ppm_correction as f32 / 1e6)) as u32
+        (self.tuner_xtal as f32 * (1.0 + self.corr as f32 / 1e6)) as u32
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
`RtlSdr` had two PPM-related fields:

  ppm_correction: u32   // initialised to 0, never reassigned
  corr: i32             // updated by set_freq_correction()

`set_freq_correction(ppm)` correctly stored `ppm` in `corr` and wrote the sample-rate compensation register, but the subsequent re-tune via `set_xtal_freq(get_tuner_xtal_freq())` and `set_center_freq(self.freq)` read the stale `ppm_correction` field — so PPM was applied to the sample-rate clock divider but **not** to the tuner's RF synthesiser.

At 274 MHz this leaves the actual tuned frequency off by `ppm × freq / 1e6` Hz (~1.4 kHz at PPM=5), which is past the pull-in range of a narrow pi/4-DQPSK demod. The corresponding librtlsdr code uses one unified field for both adjustments, so the same PPM that works through gr-osmosdr silently fails through this crate.

Fix is to drop the unused `ppm_correction` field and read `corr` directly in `get_xtal_freq` / `get_tuner_xtal_freq`. Both call sites were already cast to `f32`, so the signed-vs-unsigned change has no effect on positive PPM values and now correctly handles negative ones too.