### PR TITLE
Make Tuner: Send + Sync to allow sharing RtlSdr across threads

### DIFF
--- a/src/tuners/mod.rs
+++ b/src/tuners/mod.rs
@@ -20,7 +20,17 @@ pub struct TunerInfo {
     // pub gains: Vec<i8>,
 }
 
-pub trait Tuner: std::fmt::Debug {
+/// Per-tuner backend interface. Implementations are stored as a
+/// trait object inside [`crate::RtlSdr`], which is captured by
+/// reference from the `read_async` callback. Since `read_async`
+/// requires its closure to be `Send`, `&RtlSdr` must in turn be
+/// `Send`, which requires `RtlSdr: Sync`, which requires
+/// `Box<dyn Tuner>: Sync`. Bound the trait with `Send + Sync` so
+/// any callback that wants to query the tuner mid-stream (e.g.
+/// `read_gain` for a live AGC display) compiles. Existing
+/// implementors (`NoTuner`, `R82xx`) hold only primitive / `Copy`
+/// state so they already satisfy these auto-traits.
+pub trait Tuner: std::fmt::Debug + Send + Sync {
     fn init(&mut self, handle: &Device) -> Result<()>;
     fn get_info(&self) -> Result<TunerInfo>;
     fn get_gains(&self) -> Result<Vec<i32>>;


### PR DESCRIPTION
The dongle has separate USB endpoints for bulk streaming (EP1) and
control transfers (EP0), and libusb supports concurrent operations
on different endpoints from different threads. Taking advantage of
that — for example, running the tuner-gain readback on a side
thread alongside the bulk streaming — requires `RtlSdr: Send +
Sync`, which today fails because `Box<dyn Tuner>` carries no
auto-trait bound.

Add `Send + Sync` as supertraits of `Tuner` so the auto-traits
propagate up through the trait object and the field that stores
it, making `Arc<RwLock<RtlSdr>>` and similar patterns viable.
Both existing implementors (`NoTuner`, `R82xx`) hold only
primitive / `Copy` state and already satisfy the bound.

Note: minor breaking change for any external `Tuner` implementor —
they must now also be `Send + Sync`. In practice tuner backends
are thread-safe by construction (USB hardware abstractions with
no interior mutability), so this should be uncontroversial.