### PR TITLE
Add badges to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,8 @@
+[![crates.io](https://img.shields.io/crates/v/rtl_sdr_rs.svg)](https://crates.io/crates/rtl_sdr_rs)
+[![Documentation](https://docs.rs/rtl-sdr-rs/badge.svg)](https://docs.rs/rtl-sdr-rs/latest)
+[![MIT](https://img.shields.io/crates/l/rtl_sdr_rs.svg)](./LICENSE)
+[![Build](https://github.com/ccostes/rtl-sdr-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/ccostes/rtl-sdr-rs/actions/workflows/rust.yml)
+
 # RTL-SDR
 An RTL-SDR library written in Rust!
 


### PR DESCRIPTION
Hi and thanks for the crate! I looked into porting librtlsdr to Rust a whole ago and looking at the tuner code I quickly gave up xD

I added some badges to `readme.md` to make it easier to navigate from the GitHub repository to the relevant pages on crates.io and docs.rs. It also shows license and build status - these are not really needed, as it's displayed by GitHub anyway, but it's good to have all these in one spot.

You might also want to add the crates.io URL as a website to the GitHub repository.

