### PR TITLE
rtl_tcp: fix address parsing

### DIFF
--- a/examples/rtl_tcp.rs
+++ b/examples/rtl_tcp.rs
@@ -8,7 +8,7 @@
 //! commands to adjust frequency, sample rate, gain, and other device parameters.
 
 use rtl_sdr_rs::{DeviceId, DirectSampleMode, RtlSdr, TunerGain, DEFAULT_BUF_LENGTH, TunerId};
-use std::cmp;
+use std::{cmp, net::IpAddr};
 use std::env;
 use std::io::{self, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
@@ -85,9 +85,10 @@ fn run() -> Result<(), String> {
 
     let mut sdr = setup_device(&config)?;
 
-    let listen_addr: SocketAddr = format!("{}:{}", config.address, config.port)
-        .parse()
-        .map_err(|e| format!("Invalid listen address: {}", e))?;
+    let listen_addr = SocketAddr::new(
+        config.address.parse().map_err(|_| format!("Invalid listen address: {}", config.address))?,
+        config.port
+    );
 
     let listener =
         TcpListener::bind(listen_addr).map_err(|e| format!("Failed to bind socket: {}", e))?;

--- a/examples/rtl_tcp.rs
+++ b/examples/rtl_tcp.rs
@@ -89,7 +89,7 @@ fn run() -> Result<(), String> {
         config
             .address
             .parse()
-            .map_err(|e| format!("Invalid listen address: {}", e))?,
+            .map_err(|_| format!("Invalid listen address: {}", config.address))?,
         config.port,
     );
 

--- a/examples/rtl_tcp.rs
+++ b/examples/rtl_tcp.rs
@@ -8,7 +8,7 @@
 //! commands to adjust frequency, sample rate, gain, and other device parameters.
 
 use rtl_sdr_rs::{DeviceId, DirectSampleMode, RtlSdr, TunerGain, DEFAULT_BUF_LENGTH, TunerId};
-use std::{cmp, net::IpAddr};
+use std::cmp;
 use std::env;
 use std::io::{self, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
@@ -86,8 +86,11 @@ fn run() -> Result<(), String> {
     let mut sdr = setup_device(&config)?;
 
     let listen_addr = SocketAddr::new(
-        config.address.parse().map_err(|_| format!("Invalid listen address: {}", config.address))?,
-        config.port
+        config
+            .address
+            .parse()
+            .map_err(|e| format!("Invalid listen address: {}", e))?,
+        config.port,
     );
 
     let listener =


### PR DESCRIPTION
In `rtl_tcp` when using a IPv6 address the parsing fails. This is because it's concatenated with the port and then parsed into a `SocketAddr`.

The address should be parsed into a `IpAddr` and then combined with the port into a `SocketAddr` instead.

Before:

```
$ cargo run --example rtl_tcp -- -a "::1" -p 1234
[...]
rtl_tcp: Invalid listen address: invalid socket address syntax
```

After:

```
$ cargo run --example rtl_tcp -- -a "::1" -p 1234
[...]
Listening on [::1]:1234
```
